### PR TITLE
Configure build-backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,3 +51,4 @@ addopts = [
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Without an explicit build-backend set PEP517 builders will default to using setuptoools.

Tested with `python -m build`.