### PR TITLE
Support for H705D & H705F

### DIFF
--- a/src/govee_local_api/light_capabilities.py
+++ b/src/govee_local_api/light_capabilities.py
@@ -311,7 +311,17 @@ GOVEE_LIGHT_CAPABILITIES: dict[str, set[GoveeLightCapability]] = {
         GoveeLightCapability.COLOR_KELVIN_TEMPERATURE,
         GoveeLightCapability.BRIGHTNESS,
     },
+    "H705D": {
+        GoveeLightCapability.COLOR_RGB,
+        GoveeLightCapability.COLOR_KELVIN_TEMPERATURE,
+        GoveeLightCapability.BRIGHTNESS,
+    },
     "H705E": {
+        GoveeLightCapability.COLOR_RGB,
+        GoveeLightCapability.COLOR_KELVIN_TEMPERATURE,
+        GoveeLightCapability.BRIGHTNESS,
+    },
+    "H705F": {
         GoveeLightCapability.COLOR_RGB,
         GoveeLightCapability.COLOR_KELVIN_TEMPERATURE,
         GoveeLightCapability.BRIGHTNESS,


### PR DESCRIPTION
Added support for H705D (Permanent Outdoor Lights 2 15m), H705F (Permanent Outdoor Lights 2  45m).

 H705E (Permanent Outdoor Lights 2  30m) already existed.