### PR TITLE
feature: add segment support for H61E6 "Govee COB LED Strip Light Pro"

### DIFF
--- a/src/govee_local_api/light_capabilities.py
+++ b/src/govee_local_api/light_capabilities.py
@@ -183,7 +183,7 @@ GOVEE_LIGHT_CAPABILITIES: dict[str, GoveeLightCapabilities] = {
     "H61D5": BASIC_CAPABILITIES,
     "H61E0": BASIC_CAPABILITIES,
     "H61E1": BASIC_CAPABILITIES,
-    "H61E6": BASIC_CAPABILITIES,
+    "H61E6": create_with_capabilities(True, True, True, 15, True),
     "H61F5": BASIC_CAPABILITIES,
     "H7012": create_with_capabilities(False, False, True, 0, False),
     "H7013": create_with_capabilities(False, False, True, 0, False),


### PR DESCRIPTION
I added segment support for H61E6 "Govee COB LED Strip Light Pro":
https://eu.govee.com/en-en/products/govee-cob-strip-light-pro?variant=48557080051896

According to Govee app, it has 15 segments:
![Screenshot_20241207_142459_Govee Home](https://github.com/user-attachments/assets/1a2d5935-268b-4d45-b085-e3748f147982)
I also tested it sucessfully with the example\main.py file. Segment 1 changes the beginning, segment 15 changes the end. Works as expetcted.


In the app under "Graffit" it is possible to select 30 different segments. I don't know how this is related:
![Screenshot_20241207_142955_Govee Home](https://github.com/user-attachments/assets/8ab25531-89aa-4451-848a-32e6751d3235)


Hint: This is my first Pull Request at Github :-)

I spent some time to find out, the example\main.py doesn't work under Windows (error) or WSL2 (no device found). Only under Ubuntu booted from USB-stick it was working. Perhaps this information can be added anywhere.