### PR TITLE
Add full Support for H61E5 with 12 segments

### DIFF
--- a/src/govee_local_api/light_capabilities.py
+++ b/src/govee_local_api/light_capabilities.py
@@ -187,7 +187,7 @@ GOVEE_LIGHT_CAPABILITIES: dict[str, GoveeLightCapabilities] = {
     "H61D5": BASIC_CAPABILITIES,
     "H61E0": BASIC_CAPABILITIES,
     "H61E1": BASIC_CAPABILITIES,
-    "H61E5": BASIC_CAPABILITIES,
+    "H61E5": create_with_capabilities(True, True, True, 12, True),
     "H61E6": create_with_capabilities(True, True, True, 15, True),
     "H61F5": BASIC_CAPABILITIES,
     "H6640": create_with_capabilities(True, True, True, 8, True),


### PR DESCRIPTION
`2025-02-28 19:48:50.430 WARNING (MainThread) [homeassistant.components.govee_light_local.coordinator] Device H61E5 is not supported. Only power control is available. Please open an issue at 'https://github.com/Galorhallen/govee-local-api/issues'`

After getting this warning in HA 2025.2.5 I decided to try to fix the issue myself and add support for the device.

According to the Govee App the strip supports 12 segments when it's not cut. 
![Screenshot_20250228-192730](https://github.com/user-attachments/assets/a3bf5dcd-74b5-4c1c-9858-84e9765daf34)

After testing with example/main.py it seems like everything is working as expected.