### PR TITLE
Added full support for H6046 (10 segments)

### DIFF
--- a/src/govee_local_api/light_capabilities.py
+++ b/src/govee_local_api/light_capabilities.py
@@ -117,7 +117,7 @@ GOVEE_LIGHT_CAPABILITIES: dict[str, GoveeLightCapabilities] = {
     "H600D": BASIC_CAPABILITIES,
     "H6022": BASIC_CAPABILITIES,
     "H6042": create_with_capabilities(True, True, True, 5, True),
-    "H6046": BASIC_CAPABILITIES,
+    "H6046": create_with_capabilities(True, True, True, 10, True),
     "H6047": BASIC_CAPABILITIES,
     "H6051": BASIC_CAPABILITIES,
     "H6052": BASIC_CAPABILITIES,


### PR DESCRIPTION
The H6046 TV Light Bars were previously handled as a single light, but they actually consist of 10 individual segments—5 on each bar. The corresponding configuration has been updated to allow for more precise control of each segment. I tested the changes locally with my own light bars, and everything appears to be working perfectly.