### PR TITLE
fix: reuse_port to enable multiple calls to start

### DIFF
--- a/src/govee_local_api/controller.py
+++ b/src/govee_local_api/controller.py
@@ -111,7 +111,9 @@ class GoveeController:
 
     async def start(self):
         self._transport, self._protocol = await self._loop.create_datagram_endpoint(
-            lambda: self, local_addr=(self._listening_address, self._listening_port)
+            lambda: self,
+            local_addr=(self._listening_address, self._listening_port),
+            reuse_port=True,
         )
 
         if self._discovery_enabled or self._registry.has_queued_devices:


### PR DESCRIPTION
The homeassistant component `govee_light_local` that [uses this library](https://github.com/home-assistant/core/blob/dev/homeassistant/components/govee_light_local/coordinator.py) fails to scan multiple times because of the listenting port still being blocked by the python process. This causes an exception on the caller side documented e.g. [here](https://github.com/home-assistant/core/issues/140100) 

With this fix the scan can be started multiple times in a row from the same process.