### PR TITLE
Add support for H8022 light capabilities Fixes #186

### DIFF
--- a/src/govee_local_api/light_capabilities.py
+++ b/src/govee_local_api/light_capabilities.py
@@ -251,6 +251,7 @@ GOVEE_LIGHT_CAPABILITIES: dict[str, GoveeLightCapabilities] = {
     "H70B3": BASIC_CAPABILITIES,
     "H70BC": BASIC_CAPABILITIES,
     "H70D1": BASIC_CAPABILITIES,
+    "H8022": BASIC_CAPABILITIES,
     "H805A": create_with_capabilities(True, True, True, 0, True),
     "H805C": BASIC_CAPABILITIES,
     "H8072": create_with_capabilities(True, True, True, 8, True),


### PR DESCRIPTION
The H8022 is functionally identical to the H6022 - just appears like a newer revision. 

LAN Support works as does full color support. In home assistant light was previously detected (just with on/off vs full basic functionality). 

Fixed #186 