### PR TITLE
Fix devices not being discovered due to missing ip in message data

### DIFF
--- a/src/govee_local_api/controller.py
+++ b/src/govee_local_api/controller.py
@@ -375,6 +375,17 @@ class GoveeController:
             return
 
         if message.command == ScanResponse.command:
+            if not message.ip:
+                sender_ip, _sender_port = addr
+                self._logger.debug(
+                    "No ip returned in data from device %s!\nMessage: %s", message.device, data
+                )
+
+                message.set_ip(sender_ip)
+                self._logger.debug(
+                    "Set ip for device %s to %s (sending address).\nData: %s", message.device, sender_ip, message.data
+                )
+
             await self._handle_scan_response(cast(ScanResponse, message))
         elif message.command == DevStatusResponse.command:
             await self._handle_status_update_response(

--- a/src/govee_local_api/message.py
+++ b/src/govee_local_api/message.py
@@ -153,15 +153,18 @@ class ScanResponse(GoveeMessage):
 
     @property
     def device(self):
-        return self._data["device"]
+        return self._data.get("device", None)
 
     @property
     def sku(self):
-        return self._data["sku"]
+        return self._data.get("sku", None)
 
     @property
     def ip(self):
-        return self._data["ip"]
+        return self._data.get("ip", None)
+
+    def set_ip(self, ip_addr: str) -> None:
+        self._data["ip"] = ip_addr
 
 
 class DevStatusResponse(GoveeMessage):


### PR DESCRIPTION
When some devices respond to the scan, they don't return an IP in the message data. This diff Update the scan response class to return a default value for the property to prevent a stack trace when a key doesn't exist.  Additionally, a new method was added that allows the IP to be set when missing. The controller was updated so that when a scan response is received, it will check to determine if the IP was included in the message data. If it's missing, it will set the message IP address to the UDP message sender's IP.