### PR TITLE
Define capabilities for H7057 (H7058 already is supported)

### DIFF
--- a/src/govee_local_api/light_capabilities.py
+++ b/src/govee_local_api/light_capabilities.py
@@ -218,6 +218,7 @@ GOVEE_LIGHT_CAPABILITIES: dict[str, GoveeLightCapabilities] = {
     "H7042": BASIC_CAPABILITIES,
     "H7050": BASIC_CAPABILITIES,
     "H7051": BASIC_CAPABILITIES,
+    "H7057": create_with_capabilities(True, True, True, 0, True),
     "H7058": create_with_capabilities(True, True, True, 0, True),
     "H7055": BASIC_CAPABILITIES,
     "H705A": BASIC_CAPABILITIES,


### PR DESCRIPTION
Home assistant automatically finds the H7057 (flood lights 2) but only offers the basic control (on / off)

I did a quick read through past PRs and their [website for product details](https://us.govee.com/products/outdoor-flood-lights), it looks like the H7058 IS supported so it the just needs this line to add the missing controls.

Addresses #144 