### PR TITLE
Add light H7026

### DIFF
--- a/src/govee_local_api/light_capabilities.py
+++ b/src/govee_local_api/light_capabilities.py
@@ -213,6 +213,7 @@ GOVEE_LIGHT_CAPABILITIES: dict[str, GoveeLightCapabilities] = {
     "H7013": create_with_capabilities(False, False, True, 0, False),
     "H7021": BASIC_CAPABILITIES,
     "H7025": create_with_capabilities(True, False, True, 15, True),
+    "H7026": create_with_capabilities(True, False, True, 30, True),
     "H7028": BASIC_CAPABILITIES,
     "H7041": BASIC_CAPABILITIES,
     "H7042": BASIC_CAPABILITIES,


### PR DESCRIPTION
H7026 is identical to H7025 except that it has two chains in sequence, so twice the amount of lights.

Only concern is that the Govee app claimed H7026 had two segments, but if H7025 works with 15, H7026 should be 30.

This resolves issue #177 