### PR TITLE
Add H60B2 capability

### DIFF
--- a/src/govee_local_api/light_capabilities.py
+++ b/src/govee_local_api/light_capabilities.py
@@ -143,6 +143,7 @@ GOVEE_LIGHT_CAPABILITIES: dict[str, GoveeLightCapabilities] = {
     "H60A1": create_with_capabilities(True, True, True, 13 , True),
     "H60A4": create_with_capabilities(True, True, True, 11, False),
     "H60A6": BASIC_CAPABILITIES,
+    "H60B2": create_with_capabilities(True, True, True, 3, True),
     "H6072": create_with_capabilities(True, True, True, 8, True),
     "H6073": BASIC_CAPABILITIES,
     "H6076": BASIC_CAPABILITIES,


### PR DESCRIPTION
Add support for H60B2 (Govee Tree Floor Lamp) with 3 segments and support for colors, scenes and dimming