### PR TITLE
Add support for H7078

### DIFF
--- a/src/govee_local_api/light_capabilities.py
+++ b/src/govee_local_api/light_capabilities.py
@@ -263,6 +263,7 @@ GOVEE_LIGHT_CAPABILITIES: dict[str, GoveeLightCapabilities] = {
     "H7039": create_with_capabilities(True, True, True, 45, True),
     "H7052": create_with_capabilities(True, True, True, 15, True),
     "H7075": BASIC_CAPABILITIES,
+    "H7078": create_with_capabilities(True, True, True, 4, True),
     "H7076": create_with_capabilities(True, True, True, 15, True),
     "H70A1": create_with_capabilities(True, True, True, 15, True),
     "H70A2": create_with_capabilities(True, True, True, 20, True),


### PR DESCRIPTION
Adding support for `H7078` only sold through retailers: https://www.lowes.com/pd/Govee-Govee-Smart-Outdoor-Wall-Light/5015630805.

Has 4 segments

<img width="585" height="1092" alt="Screenshot 2025-12-15 at 2 13 51 AM" src="https://github.com/user-attachments/assets/b6eaf866-5efc-4ac4-af74-674887dd82fa" />
