### PR TITLE
Add H600A model to light capabilities

### DIFF
--- a/src/govee_local_api/light_capabilities.py
+++ b/src/govee_local_api/light_capabilities.py
@@ -115,6 +115,7 @@ ON_OFF_CAPABILITIES = create_with_capabilities(
 GOVEE_LIGHT_CAPABILITIES: dict[str, GoveeLightCapabilities] = {
     # Models with common features
     "H6008": BASIC_CAPABILITIES,
+    "H600A": BASIC_CAPABILITIES,
     "H600D": BASIC_CAPABILITIES,
     "H6020": create_with_capabilities(True, True, True, 0, True),
     "H6022": BASIC_CAPABILITIES,


### PR DESCRIPTION
Adding support for H600A bulbs. They support: RGB, Brightness, White Temperature, & Scenes. This addresses #267.