### PR TITLE
Closes #182 -  Add H601E/H601F (7 segments) support

### DIFF
--- a/src/govee_local_api/light_capabilities.py
+++ b/src/govee_local_api/light_capabilities.py
@@ -154,6 +154,8 @@ GOVEE_LIGHT_CAPABILITIES: dict[str, GoveeLightCapabilities] = {
     "H6087": create_with_capabilities(True, True, True, 12, True),
     "H610A": BASIC_CAPABILITIES,
     "H610B": BASIC_CAPABILITIES,
+    "H610E": create_with_capabilities(True, True, True, 7, False),
+    "H610F": create_with_capabilities(True, True, True, 7, False),
     "H6110": BASIC_CAPABILITIES,
     "H6117": BASIC_CAPABILITIES,
     "H612A": BASIC_CAPABILITIES,


### PR DESCRIPTION
Adds support for H601E and H601F (RGB, brightness, color temperature, 7 segments, no scenes).

Closes #182