### PR TITLE
Fix H6006: enable color temperature support (2000-9000K)

### DIFF
--- a/src/govee_local_api/light_capabilities.py
+++ b/src/govee_local_api/light_capabilities.py
@@ -115,9 +115,7 @@ ON_OFF_CAPABILITIES = create_with_capabilities(
 GOVEE_LIGHT_CAPABILITIES: dict[str, GoveeLightCapabilities] = {
     # Models with common features
     "H6004": BASIC_CAPABILITIES,
-    "H6006": create_with_capabilities(
-        True, False, True, 0, True
-    ),  # Issue #133 - no temp
+    "H6006": BASIC_CAPABILITIES,  # Issue #133 - temp confirmed via Cloud API (2000-9000K)
     "H6008": BASIC_CAPABILITIES,
     "H600A": BASIC_CAPABILITIES,
     "H600D": BASIC_CAPABILITIES,


### PR DESCRIPTION
## Summary

- Enables color temperature support for the H6006 model by switching it from a custom capability (no temp) to `BASIC_CAPABILITIES`
- The original issue #133 reported no temperature support based on a manual user checkbox, but two independent sources confirm the H6006 supports color temperature (2000-9000K):
  1. **Govee Cloud API v2** (`GET /router/api/v1/user/devices`) reports `colorTemperatureK` with range 2000-9000K
  2. **govee2mqtt** independently discovers `color_temp_range: Some((2000, 9000))` via the same API

## Evidence

Cloud API response for H6006:
```
colorTemperatureK: 2000-9000K
supports_rgb: true
supports_brightness: true
```

govee2mqtt log output:
```
Quirk { sku: "H6006", supports_rgb: true, supports_brightness: true, color_temp_range: Some((2000, 9000)), lan_api_capable: true, ... }
```

## Test plan

- [ ] Verify H6006 exposes color temperature slider in Home Assistant
- [ ] Verify color temperature commands are accepted by the device over LAN

> **Note:** Not tested end-to-end with this library — I switched to govee2mqtt which dynamically discovers capabilities and confirmed the H6006 does support color temperature. The change simply aligns the static capability definition with what Govee's own API reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)