### PR TITLE
fix: correct H7094 segment count and restore broken build (H607C comma)

### DIFF
--- a/src/govee_local_api/light_capabilities.py
+++ b/src/govee_local_api/light_capabilities.py
@@ -171,7 +171,7 @@ GOVEE_LIGHT_CAPABILITIES: dict[str, GoveeLightCapabilities] = {
     "H6076A": BASIC_CAPABILITIES,
     "H6078": BASIC_CAPABILITIES,
     "H6079": BASIC_CAPABILITIES,
-    "H607C": create_with_capabilities(True, True, True, 13, True)
+    "H607C": create_with_capabilities(True, True, True, 13, True),
     "H6087": create_with_capabilities(True, True, True, 12, True),
     "H6088": create_with_capabilities(True, True, True, 6, True),
     "H608A": BASIC_CAPABILITIES,
@@ -332,7 +332,7 @@ GOVEE_LIGHT_CAPABILITIES: dict[str, GoveeLightCapabilities] = {
     "H7086": create_with_capabilities(True, True, True, 0, True),
     "H7087": BASIC_CAPABILITIES,
     "H7093": create_with_capabilities(True, True, True, 2, True),
-    "H7094": BASIC_CAPABILITIES,
+    "H7094": create_with_capabilities(True, True, True, 4, True),
     "H70A1": create_with_capabilities(True, True, True, 15, True),
     "H70A2": create_with_capabilities(True, True, True, 20, True),
     "H70A3": create_with_capabilities(True, True, True, 15, True),


### PR DESCRIPTION
## Summary

Two small fixes in `light_capabilities.py`:

1. **Restore the build.** PR #302 dropped the trailing comma after the `H607C` entry:

   ```python
   "H607C": create_with_capabilities(True, True, True, 13, True)   # <- missing comma
   "H6087": create_with_capabilities(True, True, True, 12, True),
   ```

   This is a `SyntaxError` in a module that `device.py` and `controller.py` both import, so the **entire package fails to import**. `black` can't parse it → the `lint` job fails → `test` is skipped → the `develop` build has been red since 2026-04-13. Adding the comma back makes the file parse cleanly (no other entries affected).

2. **Correct `H7094` capabilities.** #308 added `H7094` as `BASIC_CAPABILITIES` (0 segments). The H7094 is the **4-pack** of the Outdoor Spotlights 2 — the same hardware as the `H7093` 2-pack, but with four individually addressable spotlights. It should expose **4 segments**, matching the H7093's pattern:

   ```python
   "H7093": create_with_capabilities(True, True, True, 2, True),   # 2-pack
   "H7094": create_with_capabilities(True, True, True, 4, True),   # 4-pack (was BASIC_CAPABILITIES)
   ```

## Why 4 segments

The original request (#225) noted the H7093 is "the 2 light segment version of this product", and downstream projects independently report the H7094 exposes 4 controllable segments (one per spotlight).

## Verification

- `poetry run pytest` → 20 passed (was 3 collection errors before this change).
- `black --check` and the full pre-commit suite (ruff, ruff-format, codespell, prettier, mypy) pass.
- **Tested against real hardware** via local UDP discovery. A physical H7094 now resolves to 4 segments with full RGB / color-temperature / brightness / scenes instead of the on/off-only fallback; H7093 units correctly report 2 segments.

## Notes

Issue #225 was closed as fixed by #308, but the entry shipped with the wrong segment count and as part of the batch that broke the build (and there has been no release since v2.4.0). This PR completes that fix and unblocks the `develop` → release path.

Closes #225